### PR TITLE
Properly restore stack value in dom handler

### DIFF
--- a/xmlhandler/dom.lua
+++ b/xmlhandler/dom.lua
@@ -66,6 +66,7 @@ function dom:endtag(tag, s)
     end
 
     table.remove(self._stack)
+    self.current = self._stack[#self._stack]
 end
 
 ---Parses a tag content.


### PR DESCRIPTION
Currently the DOM handler keeps track of the current element using a stack, but when removing the last element from the stack the previous element isn't restored to `self.current`. Therefore subsequent elements appear nested, e.g. a document like

    <a>
      <b />
      <c />
    </a>

is parsed as if it was

    <a>
      <b>
        <c />
      </b>
    </a>

This can be fixed by assigning the top of the stack to `self.current` after removing an element from the stack.