### PR TITLE
Fix #51: unable to parse node name/attribute 'n'

### DIFF
--- a/xmlhandler/dom.lua
+++ b/xmlhandler/dom.lua
@@ -1,7 +1,7 @@
 local function init()
     return {
         options = {commentNode=1, piNode=1, dtdNode=1, declNode=1},
-        current = { _children = {_n=0}, _type = "ROOT" },
+        current = { _children = {}, _type = "ROOT" },
         _stack = {}
     }
 end
@@ -58,7 +58,7 @@ function dom:starttag(tag)
     local node = { _type = 'ELEMENT', 
                    _name = tag.name, 
                    _attr = tag.attrs, 
-                   _children = {_n=0} 
+                   _children = {} 
                  }
             
     if self.root == nil then

--- a/xmlhandler/dom.lua
+++ b/xmlhandler/dom.lua
@@ -1,7 +1,7 @@
 local function init()
     return {
         options = {commentNode=1, piNode=1, dtdNode=1, declNode=1},
-        current = { _children = {n=0}, _type = "ROOT" },
+        current = { _children = {_n=0}, _type = "ROOT" },
         _stack = {}
     }
 end
@@ -58,7 +58,7 @@ function dom:starttag(tag)
     local node = { _type = 'ELEMENT', 
                    _name = tag.name, 
                    _attr = tag.attrs, 
-                   _children = {n=0} 
+                   _children = {_n=0} 
                  }
             
     if self.root == nil then

--- a/xmlhandler/tree.lua
+++ b/xmlhandler/tree.lua
@@ -4,7 +4,7 @@ local function init()
         options = {noreduce = {}}
     }
     
-    obj._stack = {obj.root, n=1}  
+    obj._stack = {obj.root}  
     return obj  
 end
 
@@ -82,8 +82,6 @@ function tree:reduce(node, key, parent)
     if #node == 1 and not self.options.noreduce[key] and 
         node._attr == nil then
         parent[key] = node[1]
-    else
-        node.n = nil
     end
 end
 
@@ -103,7 +101,7 @@ function tree:starttag(tag)
     if current[tag.name] then
         table.insert(current[tag.name], node)
     else
-        current[tag.name] = {node; n=1}
+        current[tag.name] = {node}
     end
 
     table.insert(self._stack, node)


### PR DESCRIPTION
Fix #51 

I could be wrong but by checking the code it seems like the `n` field is not used for `_children` and `obj._stack`.
The following test case is passed:
```lua
local xml2lua         = require("xml2lua")
local tree_handler    = require("xmlhandler.tree")
local message_handler = tree_handler:new()
local parser          = xml2lua.parser(message_handler)
local stanza          = [[<message><ext><from n='name1' res='res1'/></ext><n>abc</n></message>]]
parser:parse(stanza)
print(message_handler.root.message.ext.from._attr.n)
print(message_handler.root.message.n)
```