### PR TITLE
Relax tree:reduce to consider any node children other than those by #node

### DIFF
--- a/xmlhandler/tree.lua
+++ b/xmlhandler/tree.lua
@@ -86,8 +86,7 @@ function tree:reduce(node, key, parent)
             self:reduce(v,k,node)
         end
     end
-    if #node == 1 and not size_greater_than(node, 1) and not self.options.noreduce[key] and 
-        node._attr == nil then
+    if #node == 1 and not size_greater_than(node, 1) and not self.options.noreduce[key] then
         parent[key] = node[1]
     end
 end

--- a/xmlhandler/tree.lua
+++ b/xmlhandler/tree.lua
@@ -71,6 +71,13 @@ function tree:new()
     return obj
 end
 
+local function size_greater_than(t, n)
+    for _, _ in pairs(t) do
+        if 0 == n then return true end
+        n = n - 1
+    end
+end
+
 --- Recursively removes redundant vectors for nodes
 -- with single child elements
 function tree:reduce(node, key, parent)
@@ -79,7 +86,7 @@ function tree:reduce(node, key, parent)
             self:reduce(v,k,node)
         end
     end
-    if #node == 1 and not self.options.noreduce[key] and 
+    if #node == 1 and not size_greater_than(node, 1) and not self.options.noreduce[key] and 
         node._attr == nil then
         parent[key] = node[1]
     end


### PR DESCRIPTION
xmlhandler.tree parsing of ...

```
<?xml version="1.0" encoding="utf-8" ?>
<device>
        T
        <manufacturer>M</manufacturer>
</device>
```

... will reduce the manufacturer_node to {manufacturer = 'M'}.
When reducing the device_node, it will have two children ({[1] = 'T', manufacturer = 'M'}) but #device_node will only count one so it will be reduced into the parent_node ({device = 'T'}).

This pull request fixes this problem.