### PR TITLE
Dom handler fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,6 @@ test:
 lint:
 	docker-compose run --rm lint
 
-example5:
-	lua example5.lua < people.xml
-	lua example5.lua < books.xml
-
 clean:
 	find . -name '*~' -delete
 

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,11 @@ test:
 lint:
 	docker-compose run --rm lint
 
-.PHONY: lint test all
+example5:
+	lua example5.lua < people.xml
+	lua example5.lua < books.xml
+
+clean:
+	find . -name '*~' -delete
+
+.PHONY: lint test all example5 clean

--- a/README.adoc
+++ b/README.adoc
@@ -80,8 +80,8 @@ local xml = [[
   <person type="legal">
     <name>University of Brasília</name>
     <city>Brasília-DF</city>
-  </person>  
-</people>    
+  </person>
+</people>
 ]]
 
 --Instantiates the XML parser
@@ -121,7 +121,7 @@ Execute `lua testxml.lua -help` on the terminal for more details.
 
 == Running tests
 
-=== Requeriments
+=== Requirements
 
 You must have https://docs.docker.com/compose/install/[installed docker and docker compose].
 

--- a/XmlParser.lua
+++ b/XmlParser.lua
@@ -43,7 +43,7 @@ local function hexadecimalToHtmlChar(code)
 end
 
 local XmlParser = {
-    -- Private attribures/functions
+    -- Private attributes/functions
     _XML        = '^([^<]*)<(%/?)([^>]-)(%/?)>',
     _ATTR1      = '([%w-:_]+)%s*=%s*"(.-)"',
     _ATTR2      = '([%w-:_]+)%s*=%s*\'(.-)\'',
@@ -56,10 +56,10 @@ local XmlParser = {
     _WS         = '^%s*$',
     _DTD1       = '<!DOCTYPE%s+(.-)%s+(SYSTEM)%s+["\'](.-)["\']%s*(%b[])%s*>',
     _DTD2       = '<!DOCTYPE%s+(.-)%s+(PUBLIC)%s+["\'](.-)["\']%s+["\'](.-)["\']%s*(%b[])%s*>',
-    --_DTD3       = '<!DOCTYPE%s+(.-)%s*(%b[])%s*>',
-    _DTD3       = '<!DOCTYPE%s.->',
+    _DTD3       = '<!DOCTYPE%s+(.-)%s+%[%s+.-%]>', -- Inline DTD Schema
     _DTD4       = '<!DOCTYPE%s+(.-)%s+(SYSTEM)%s+["\'](.-)["\']%s*>',
     _DTD5       = '<!DOCTYPE%s+(.-)%s+(PUBLIC)%s+["\'](.-)["\']%s+["\'](.-)["\']%s*>',
+    _DTD6       = '<!DOCTYPE%s+(.-)%s+(PUBLIC)%s+["\'](.-)["\']%s*>',
 
     --Matches an attribute with non-closing double quotes (The equal sign is matched non-greedly by using =+?)
     _ATTRERR1   = '=+?%s*"[^"]*$',
@@ -246,7 +246,7 @@ end
 
 local function _parseDtd(self, xml, pos)
     -- match,endMatch,root,type,name,uri,internal
-    local dtdPatterns = {self._DTD1, self._DTD2, self._DTD3, self._DTD4, self._DTD5}
+    local dtdPatterns = {self._DTD1, self._DTD2, self._DTD3, self._DTD4, self._DTD5, self._DTD6}
 
     for _, dtd in pairs(dtdPatterns) do
         local m,e,r,t,n,u,i = string.find(xml, dtd, pos)

--- a/books.xml
+++ b/books.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <!-- Source: https://msdn.microsoft.com/en-us/library/ms762271(v=vs.85).aspx -->
+<!DOCTYPE name PUBLIC "-//Beginning XML//DTD Address Example//EN">
 <catalog>
    <book>
       <author>Gambardella, Matthew</author>

--- a/example1.lua
+++ b/example1.lua
@@ -10,7 +10,7 @@ print("xml2lua v" .. xml2lua._VERSION.."\n")
 local handler = require("xmlhandler.tree")
 
 
-local xml = xml2lua.loadFile("people.xml")
+local xml = xml2lua.loadFile("people1.xml")
 
 --Instantiates the XML parser
 local parser = xml2lua.parser(handler)

--- a/example2.lua
+++ b/example2.lua
@@ -9,11 +9,11 @@ print("xml2lua v" .. xml2lua._VERSION.."\n")
 --Uses a handler that converts the XML to a Lua table
 local handler = require("xmlhandler.tree")
 
------------------------  people.xml parse code -----------------------
-print("people.xml")
+-----------------------  people1.xml parse code -----------------------
+print("people1.xml")
 local peopleHandler = handler:new()
 local peopleParser = xml2lua.parser(peopleHandler)
-peopleParser:parse(xml2lua.loadFile("people.xml"))
+peopleParser:parse(xml2lua.loadFile("people1.xml"))
 xml2lua.printable(peopleHandler.root)
 
 -----------------------  books.xml parse code -----------------------

--- a/example5.lua
+++ b/example5.lua
@@ -6,7 +6,7 @@ local xml2lua = require("xml2lua")
 local dom = require("xmlhandler.dom")
 local parser = xml2lua.parser(dom)
 parser:parse(io.read("*all"))
-if dom.root == nil then
+if not dom.root then
    print("parsing as XML failed")
 else
    print(dom:toXml(dom.root))

--- a/example5.lua
+++ b/example5.lua
@@ -1,0 +1,13 @@
+#!/usr/bin/env lua
+-- read a XML document in STDIN,
+-- parse with the dom parser,
+-- print the XML document to STDOUT.
+local xml2lua = require("xml2lua")
+local dom = require("xmlhandler.dom")
+local parser = xml2lua.parser(dom)
+parser:parse(io.read("*all"))
+if dom.root == nil then
+   print("parsing as XML failed")
+else
+   print(dom:toXml(dom.root))
+end

--- a/example5.lua
+++ b/example5.lua
@@ -1,13 +1,20 @@
 #!/usr/bin/env lua
--- read a XML document in STDIN,
+-- Read XML documents containing DOCTYPE and CDATA tags,
 -- parse with the dom parser,
--- print the XML document to STDOUT.
+-- print the XML documents to STDOUT.
 local xml2lua = require("xml2lua")
-local dom = require("xmlhandler.dom")
-local parser = xml2lua.parser(dom)
-parser:parse(io.read("*all"))
-if not dom.root then
-   print("parsing as XML failed")
-else
-   print(dom:toXml(dom.root))
+local xmlhandler = require("xmlhandler.dom")
+
+local files = {"books.xml", "people2.xml"}
+for _, file in ipairs(files) do
+   print(file, "-----------------------------------------------------------")
+   local xml = xml2lua.loadFile(file)
+   local dom = xmlhandler:new()
+   local parser = xml2lua.parser(dom)
+   parser:parse(xml)
+   if not dom.root then
+      print("parsing ", file , " as XML failed")
+   else
+      print(dom:toXml(dom.root))
+   end
 end

--- a/people.xml
+++ b/people.xml
@@ -19,5 +19,7 @@
   <person type="legal">
     <name>University of Brasília</name>
     <city>Brasília-DF</city>
-  </person>  
+    <empty></empty>
+    <void/>
+  </person>
 </people>

--- a/people.xml
+++ b/people.xml
@@ -1,4 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE person [
+   <!ELEMENT person (name,city,empty,void)>
+   <!ELEMENT name (#PCDATA)>
+   <!ELEMENT city (#PCDATA)>
+   <!ELEMENT void (#PCDATA)>
+   <!ELEMENT empty (#PCDATA)>
+]>
 <people>
   <person type="natural">
     <![CDATA[

--- a/people1.xml
+++ b/people1.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<people>
+  <person type="natural">
+    <!-- Just an example comment that will be ignored by the tree
+    handler and processed by the other ones. -->
+    
+    <name>Manoel</name>
+    <city>Palmas-TO</city>
+  </person>
+  <person type="natural">
+    <name>Breno</name>
+    <city>Palmas-TO</city>
+  </person>
+  <person type="legal">
+    <name>University of Brasília</name>
+    <city>Brasília-DF</city>
+    <empty></empty>
+    <void/>
+  </person>
+</people>

--- a/people2.xml
+++ b/people2.xml
@@ -1,4 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- A more complex people XML with DOCTYPE and CDATA tags -->
+
 <!DOCTYPE person [
    <!ELEMENT person (name,city,empty,void)>
    <!ELEMENT name (#PCDATA)>
@@ -13,8 +15,6 @@
     such as <tag>message</tag>.
     Its content is extracted but not processed.
     ]]>  
-    
-    <!-- Just an example comment that will be ignored by the tree handler and processed by the other ones. -->
     
     <name>Manoel</name>
     <city>Palmas-TO</city>

--- a/xmlhandler/dom.lua
+++ b/xmlhandler/dom.lua
@@ -86,6 +86,9 @@ function dom:endtag(tag, s)
 
     table.remove(self._stack)
     self.current = self._stack[#self._stack]
+	if (self.current == nil) then
+		self.current = { _children = {n=0}, _type = "ROOT" };
+	end
 end
 
 ---Parses a tag content.

--- a/xmlhandler/dom.lua
+++ b/xmlhandler/dom.lua
@@ -226,7 +226,9 @@ local function toXmlStr(node, indentLevel)
    elseif node._type == 'ELEMENT' then
       local s = indent .. '<' .. node._name .. attrsToStr(node._attr)
 
-      if not node._children then
+      -- check if ELEMENT has no children
+      if not node._children or
+	 #node._children == 0 then
 	 return s .. '/>\n'
       end
 

--- a/xmlhandler/dom.lua
+++ b/xmlhandler/dom.lua
@@ -153,7 +153,7 @@ end
 
 ---Parses a DTD tag.
 -- @param tag a {name, value} table
--- where name is the name of the tag and attrs
+-- where name is the name of the tag and value
 -- is a table containing the attributes of the tag
 function dom:dtd(tag)
    if self.options.dtdNode then

--- a/xmlhandler/dom.lua
+++ b/xmlhandler/dom.lua
@@ -92,6 +92,10 @@ function dom:endtag(tag)
 	  table.insert(node._children, self.decl)
 	  self.decl = nil
        end
+       if self.dtd then
+	  table.insert(node._children, self.dtd)
+	  self.dtd = nil
+       end
        if self.root then
 	  table.insert(node._children, self.root)
 	  self.root = node
@@ -139,28 +143,25 @@ end
 -- where name is the name of the tag and attrs
 -- is a table containing the attributes of the tag
 function dom:decl(tag)
-    if self.options.declNode then
-       local node = { _type = "DECL",
-		       _name = tag.name,
-		       _attr = tag.attrs,
-                    }
-       self.decl = node
-       --table.insert(self.current._children, node)
-    end
+   if self.options.declNode then
+      self.decl = { _type = "DECL",
+		    _name = tag.name,
+		    _attr = tag.attrs,
+      }
+   end
 end
 
 ---Parses a DTD tag.
--- @param tag a {name, attrs} table
+-- @param tag a {name, value} table
 -- where name is the name of the tag and attrs
 -- is a table containing the attributes of the tag
 function dom:dtd(tag)
-    if self.options.dtdNode then
-        local node = { _type = "DTD",
-                       _name = tag.name,
-                       _attr = tag.attrs,
-                     }
-        table.insert(self.current._children, node)
-    end
+   if self.options.dtdNode then
+      self.dtd = { _type = "DTD",
+		   _name = tag.name,
+		   _text = tag.value
+      }
+   end
 end
 
 --- XML escape characters for a TEXT node.
@@ -254,11 +255,14 @@ local function toXmlStr(node, indentLevel)
    elseif node._type == 'DECL' then
       return indent .. '<?' .. node._name .. attrsToStr(node._attr) .. '?>\n'
    elseif node._type == 'DTD' then
-      return indent .. '<!--DTD not implemented-->\n' -- TODO
+      return indent .. '<!' .. node._name .. ' ' .. node._text .. '>\n'
    end
    return 'BUG:unknown type:' .. tostring(node._type)
 end
 
+---create a string in XML format from the dom root object @p node.
+-- @param node a root object, typically created with `dom` XML parser handler.
+-- @return a string, XML formatted.
 function dom:toXml(node)
    return toXmlStr(node, -4)
 end


### PR DESCRIPTION
# Fix #79

These changes fix the DOM handler:
* create a ROOT node as described in the description in the dom.lua file.
* place the DECL node as the first child node of ROOT if present.
* place the DTD node as the second child node of ROOT if present.
* place the root ELEMENT node as the third child node of ROOT.
* add a function dom:toXml(node) that will create a XML formatted string of a DOM ROOT node.
* fix some typos.
* remove some trailing whitespace.