### PR TITLE
Write XML tags with both attr and value, substitute reserved chars when converting table to XML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,15 @@
 *.rock
-test.lua
-teste.lua
 
 #IntelliJ IDEA Files
 .idea
 *.iml
 
+#VS Code files
+launch.json
+
 #macOS
 .DS_Store
+
+#Debugging files 
+debugger.lua
+test.lua

--- a/xml2lua.lua
+++ b/xml2lua.lua
@@ -237,7 +237,7 @@ end
 
 function xml2lua.parseTableToXml(obj, tagName, level)
   if (tagName ~= '_attr') then
-    if (type(obj) == 'table') then
+    if (type(obj) == 'table' and (#obj ~= 1 or type(obj[1]) == 'table')) then
       if (xml2lua.isChildArray(obj)) then
         for _, value in pairs(obj) do
           xml2lua.parseTableToXml(value, tagName, level)
@@ -252,10 +252,14 @@ function xml2lua.parseTableToXml(obj, tagName, level)
         xml2lua.endTag(tagName, level)
       end
     else
-      xml2lua.addTagValueAttr(tagName, obj, nil, level)
+      if type(obj) == 'table' then
+        xml2lua.addTagValueAttr(tagName, obj[1], obj._attr, level)
+      else
+        xml2lua.addTagValueAttr(tagName, obj, nil, level)
+      end
     end
   end
-    end
+end
 
 ---Converts a Lua table to a XML String representation.
 --@param tb Table to be converted to XML


### PR DESCRIPTION
Altered the function to create tags for writing to give the possibility of having both attributes and regular values on the same tag.

Added check for all attribute values and regular values to substitute reserved characters with their escaped variants when writing XML from table.